### PR TITLE
tf-idf embeddings for search

### DIFF
--- a/upgrade_logic/business_objects/gateway.py
+++ b/upgrade_logic/business_objects/gateway.py
@@ -12,45 +12,8 @@ from submodules.model import enums
 
 
 def gateway_1_15_0() -> bool:
-    # here, we update data for cognition using the gateway pattern
-    # as the corresponding database updates (alembic) are managed using the refinery gateway it is
-    # ensured that these updates are executed at the correct time
-    __gateway_1_15_0_add_cognition_project_file_defaults()
-    __gateway_1_15_0_add_cognition_conversation_file_defaults()
-    __gateway_1_15_0_remove_cognition_step_type_relevance()
-    return True
-
-
-def __gateway_1_15_0_add_cognition_project_file_defaults() -> bool:
-    query = """
-    UPDATE cognition.project
-    SET max_file_size_mb = 3,
-        allow_file_upload = FALSE
-    WHERE max_file_size_mb IS NULL
-    """
-    general.execute(query)
-    general.commit()
-    return True
-
-
-def __gateway_1_15_0_add_cognition_conversation_file_defaults() -> bool:
-    query = """
-    UPDATE cognition.conversation
-    SET has_tmp_files = FALSE,
-        archived = FALSE
-    WHERE has_tmp_files IS NULL
-    """
-    general.execute(query)
-    general.commit()
-    return True
-
-
-def __gateway_1_15_0_remove_cognition_step_type_relevance() -> bool:
-    query = """
-    DELETE FROM cognition.strategy_step WHERE step_type = 'RELEVANCE'
-    """
-    general.execute(query)
-    general.commit()
+    # Note: A previous version had the previous update listed as v1.15.
+    # That was false, the updates already ran through. This is now for the actual 1.15 release
     return True
 
 
@@ -60,6 +23,9 @@ def gateway_1_14_0() -> bool:
     # ensured that these updates are executed at the correct time
     gateway_1_14_0_add_cognition_project_state()
     gateway_1_14_0_add_cognition_strategy_complexity()
+    __gateway_1_14_0_add_cognition_project_file_defaults()
+    __gateway_1_14_0_add_cognition_conversation_file_defaults()
+    __gateway_1_14_0_remove_cognition_step_type_relevance()
     return True
 
 
@@ -91,6 +57,39 @@ def gateway_1_14_0_add_cognition_strategy_complexity() -> bool:
         )
         return False
 
+    return True
+
+
+def __gateway_1_14_0_add_cognition_project_file_defaults() -> bool:
+    query = """
+    UPDATE cognition.project
+    SET max_file_size_mb = 3,
+        allow_file_upload = FALSE
+    WHERE max_file_size_mb IS NULL
+    """
+    general.execute(query)
+    general.commit()
+    return True
+
+
+def __gateway_1_14_0_add_cognition_conversation_file_defaults() -> bool:
+    query = """
+    UPDATE cognition.conversation
+    SET has_tmp_files = FALSE,
+        archived = FALSE
+    WHERE has_tmp_files IS NULL
+    """
+    general.execute(query)
+    general.commit()
+    return True
+
+
+def __gateway_1_14_0_remove_cognition_step_type_relevance() -> bool:
+    query = """
+    DELETE FROM cognition.strategy_step WHERE step_type = 'RELEVANCE'
+    """
+    general.execute(query)
+    general.commit()
     return True
 
 

--- a/upgrade_logic/business_objects/neural_search.py
+++ b/upgrade_logic/business_objects/neural_search.py
@@ -14,7 +14,7 @@ def neural_search_1_15_0() -> bool:
 
 def neural_search_1_15_0_delete_all_tf_idf_embeddings() -> bool:
     # previous tf-idf embeddings didn't do anything useful so we can just delete them
-    # Note that tensors are deleted by cascading
+    # used fixed values instead of enum keys to ensure changes dont break
     query = "SELECT id FROM embedding WHERE platform = 'python' AND model = 'tf-idf'"
     embedding_ids = general.execute_all(query)
     if len(embedding_ids) > 0:
@@ -27,11 +27,12 @@ def neural_search_1_15_0_delete_all_tf_idf_embeddings() -> bool:
                 print(
                     f"Error deleting tf-idf embedding {embedding_id[0]} from qdrant: {e}"
                 )
-                return False
 
+        # Note that tensors are deleted by cascading
         query = "DELETE FROM embedding WHERE platform = 'python' AND model = 'tf-idf'"
         general.execute(query)
         general.commit()
+    return True
 
 
 def neural_search_1_12_0() -> bool:

--- a/upgrade_logic/business_objects/neural_search.py
+++ b/upgrade_logic/business_objects/neural_search.py
@@ -1,10 +1,37 @@
 import os
 import requests
 
-from submodules.model.business_objects import embedding
+from submodules.model.business_objects import embedding, general
 
 
 NEURAL_SEARCH = os.getenv("NEURAL_SEARCH")
+
+
+def neural_search_1_15_0() -> bool:
+    neural_search_1_15_0_delete_all_tf_idf_embeddings()
+    return True
+
+
+def neural_search_1_15_0_delete_all_tf_idf_embeddings() -> bool:
+    # previous tf-idf embeddings didn't do anything useful so we can just delete them
+    # Note that tensors are deleted by cascading
+    query = "SELECT id FROM embedding WHERE platform = 'python' AND model = 'tf-idf'"
+    embedding_ids = general.execute_all(query)
+    if len(embedding_ids) > 0:
+        url_delete = f"{NEURAL_SEARCH}/delete_collection"
+        for embedding_id in embedding_ids:
+            try:
+                params = {"embedding_id": embedding_id[0]}
+                requests.put(url_delete, params=params)
+            except Exception as e:
+                print(
+                    f"Error deleting tf-idf embedding {embedding_id[0]} from qdrant: {e}"
+                )
+                return False
+
+        query = "DELETE FROM embedding WHERE platform = 'python' AND model = 'tf-idf'"
+        general.execute(query)
+        general.commit()
 
 
 def neural_search_1_12_0() -> bool:


### PR DESCRIPTION
main PR: https://github.com/code-kern-ai/refinery-embedder/pull/89

Note:
Not really needed as we don't have any on the production server (checked 22.04.).
For completion sake (and local / os users) we should still keep it imo

easiest to test by creating a tf-idf embedding and running the update through
`http://localhost:7062/docs#/default/helper_function_helper_function_post`
after that postgres & [qdrant](http://localhost:6333/dashboard) can be checked for the embedding => hopefully gone